### PR TITLE
hotfix/ nightly edits

### DIFF
--- a/src/apis/lock.ts
+++ b/src/apis/lock.ts
@@ -201,7 +201,7 @@ export class Lock {
 
       for (const event of lockCreatedEvents) {
         if (!xsLockIDs_burned.includes(event.args?.tokenId.toNumber())) {
-          xsLockIDs.push(event.args?.tokenId.toNumber())
+          xsLockIDs.push(event.args?.tokenId)
         } 
       }
 


### PR DESCRIPTION
- In the process of returning IDs of locks that were created and not burned, their types became numbers instead of BigNumbers despite the return type of the function requires them so. Typescript couldn't pick this up, but this issue was found when trying to call the function from the frontend app.